### PR TITLE
add GetByString to avoid allocation using strings with Get

### DIFF
--- a/intern_test.go
+++ b/intern_test.go
@@ -5,6 +5,7 @@
 package intern
 
 import (
+	"fmt"
 	"runtime"
 	"testing"
 )
@@ -13,17 +14,31 @@ func TestBasics(t *testing.T) {
 	clearMap()
 	foo := Get("foo")
 	bar := Get("bar")
+	empty := Get("")
+	nilEface := Get(nil)
+	i := Get(0x7777777)
 	foo2 := Get("foo")
 	bar2 := Get("bar")
+	empty2 := Get("")
+	nilEface2 := Get(nil)
+	i2 := Get(0x7777777)
+	foo3 := GetByString("foo")
+	empty3 := GetByString("")
 
 	if foo.Get() != foo2.Get() {
-		t.Error("foo values differ")
+		t.Error("foo/foo2 values differ")
+	}
+	if foo.Get() != foo3.Get() {
+		t.Error("foo/foo3 values differ")
 	}
 	if foo.Get() != "foo" {
 		t.Error("foo.Get not foo")
 	}
 	if foo != foo2 {
-		t.Error("foo pointers differ")
+		t.Error("foo/foo2 pointers differ")
+	}
+	if foo != foo3 {
+		t.Error("foo/foo3 pointers differ")
 	}
 
 	if bar.Get() != bar2.Get() {
@@ -36,8 +51,44 @@ func TestBasics(t *testing.T) {
 		t.Error("bar pointers differ")
 	}
 
-	if n := mapLen(); n != 2 {
-		t.Errorf("map len = %d; want 2", n)
+	if i.Get() != i.Get() {
+		t.Error("i values differ")
+	}
+	if i.Get() != 0x7777777 {
+		t.Error("i.Get not 0x7777777")
+	}
+	if i != i2 {
+		t.Error("i pointers differ")
+	}
+
+	if empty.Get() != empty2.Get() {
+		t.Error("empty/empty2 values differ")
+	}
+	if empty.Get() != empty.Get() {
+		t.Error("empty/empty3 values differ")
+	}
+	if empty.Get() != "" {
+		t.Error("empty.Get not empty string")
+	}
+	if empty != empty2 {
+		t.Error("empty/empty2 pointers differ")
+	}
+	if empty != empty3 {
+		t.Error("empty/empty3 pointers differ")
+	}
+
+	if nilEface.Get() != nilEface2.Get() {
+		t.Error("nilEface values differ")
+	}
+	if nilEface.Get() != nil {
+		t.Error("nilEface.Get not nil")
+	}
+	if nilEface != nilEface2 {
+		t.Error("nilEface pointers differ")
+	}
+
+	if n := mapLen(); n != 5 {
+		t.Errorf("map len = %d; want 4", n)
 	}
 
 	wantEmpty(t)
@@ -53,7 +104,7 @@ func wantEmpty(t testing.TB) {
 			break
 		}
 		if try == gcTries-1 {
-			t.Errorf("map len = %d after (%d GC tries); want 0", n, gcTries)
+			t.Errorf("map len = %d after (%d GC tries); want 0, contents: %v", n, gcTries, mapKeys())
 		}
 	}
 }
@@ -108,10 +159,41 @@ func mapLen() int {
 	return len(valMap)
 }
 
+func mapKeys() (keys []string) {
+	mu.Lock()
+	defer mu.Unlock()
+	for k := range valMap {
+		keys = append(keys, fmt.Sprint(k))
+	}
+	return keys
+}
+
 func clearMap() {
 	mu.Lock()
 	defer mu.Unlock()
 	for k := range valMap {
 		delete(valMap, k)
+	}
+}
+
+var (
+	globalString = "not a constant"
+	sink         string
+)
+
+func TestGetByStringAllocs(t *testing.T) {
+	allocs := int(testing.AllocsPerRun(100, func() {
+		GetByString(globalString)
+	}))
+	if allocs != 0 {
+		t.Errorf("GetString allocated %d objects, want 0", allocs)
+	}
+}
+
+func BenchmarkGetByString(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		v := GetByString(globalString)
+		sink = v.Get().(string)
 	}
 }


### PR DESCRIPTION
This is an alternative to #10. It was surprisingly difficult to get correct. I'm not sure that it is better than duplicating the code for Get; also, once we have generics, the duplicated code for Get disappears, whereas this approach doesn't. But if you prefer this, I'm OK also going this route.
