### PR TITLE
Separate get modes in different funcs

### DIFF
--- a/intern.go
+++ b/intern.go
@@ -114,7 +114,7 @@ func GetByString(s string) *Value {
 }
 
 // leakyGet in safe+leaky mode is simple and safe, but may grow forever. It is
-// subjec to DOS attacks
+// subject to DOS attacks
 func leakyGet(k key) *Value {
 	mu.Lock()
 	defer mu.Unlock()

--- a/intern.go
+++ b/intern.go
@@ -66,9 +66,9 @@ func (k key) Value() *Value {
 var (
 	// mu guards valMap, a weakref map of *Value by underlying value.
 	// It also guards the resurrected field of all *Values.
-	mu        sync.Mutex
-	valMap    = map[key]uintptr{} // to uintptr(*Value)
-	valSafe   = safeMap()         // non-nil in safe+leaky mode
+	mu      sync.Mutex
+	valMap  = map[key]uintptr{} // to uintptr(*Value)
+	valSafe = safeMap()         // non-nil in safe+leaky mode
 )
 
 // safeMap returns a non-nil map if we're in safe-but-leaky mode,


### PR DESCRIPTION
I believe this way the code is more readable, easy to maintain and less error prone.

The separate get functions save some `if`s and only need to deal with a single operation mode each. The `get` implementation is chosen at initialisation time once. Just as `valSafe()` was choosing the operation mode before.

This is just a refactor, the functionality should stay exactly the same. Otherwise it was an unintended mistake.
